### PR TITLE
Removed creation of 'alone' user

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ FROM godaddy/node:8.9.4-debian
 
 ENV NODE_ENV=production # or anything else
 
-USER node
 RUN mkdir /app
 WORKDIR /app
 
@@ -26,9 +25,7 @@ RUN npm install
 
 # Copy app to source directory
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
-COPY . /app
-
-USER root
+COPY . /app/
 
 EXPOSE 8080
 CMD ["gosu", "node", "npm", "start"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ FROM godaddy/node:8.9.4-debian
 
 ENV NODE_ENV=production # or anything else
 
+USER node
+RUN mkdir /app
 WORKDIR /app
+
 COPY docker/.npmrc package.json package-lock.json /app/
 
 RUN npm install
@@ -25,8 +28,10 @@ RUN npm install
 COPY docker/docker-entrypoint.sh /docker-entrypoint.sh
 COPY . /app
 
+USER root
+
 EXPOSE 8080
-CMD ["gosu", "alone", "npm", "start"]
+CMD ["gosu", "node", "npm", "start"]
 ```
 
 ## Docker-entrypoint.sh
@@ -37,8 +42,6 @@ CMD ["gosu", "alone", "npm", "start"]
 # here you can customize how your app should start up
 set -e
 
-cd /app
-chown alone:alone /app
 exec "$@"
 ```
 

--- a/debian/Dockerfile.hbs
+++ b/debian/Dockerfile.hbs
@@ -20,13 +20,7 @@ RUN set -x \
     && gosu nobody true \
     && apt-get purge -y --auto-remove ca-certificates wget
 
-# create directory to host application files
-RUN mkdir -p /home/alone/app
-
-# this will be mounted as a volume in the build process
-WORKDIR /home/alone/app
-
-# base-entrypoint allows us to create a user/group with configureable UID/GID
+# base-entrypoint allows us to update the node uid/gid
 COPY base-entrypoint.sh /
 
 # make sure we can execute base-entrypoint.sh
@@ -35,7 +29,7 @@ RUN chmod +x /base-entrypoint.sh
 # this will be the entrypoint script for the child container
 ONBUILD COPY docker-entrypoint.sh /
 
-# this will handle creating the user/group and running the docker-entrypoint.sh
+# this will handle updating the node uid/gid and running the docker-entrypoint.sh
 # provided by the child image
 ENTRYPOINT ["/base-entrypoint.sh"]
 

--- a/debian/base-entrypoint.sh
+++ b/debian/base-entrypoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 
-# create alone user/group so we aren't forced to run app as root
-id -u alone 2>/dev/null
-if [ $? -ne 0 ]; then
-  groupadd -r alone --gid=$APP_GROUP_ID
-  useradd -r -g alone -d /home/alone -c "alone app user" --uid=$APP_USER_ID alone
-  echo "created alone user/group with UID/GID: $APP_USER_ID/$APP_GROUP_ID"
-else
-  echo "alone user already exists"
+CURRENT_UID=`id -u node 2>/dev/null`
+CURRENT_GID=`id -g node 2>/dev/null`
+
+# if either APP_USER_ID or APP_GROUP_ID environment variables exist,
+# the node user's uid/gid will be updated accordingly. this is useful
+# if you want to avoid permissions issues when mounting volumes
+if [ ! -z "$APP_USER_ID" -o ! -z "$APP_GROUP_ID" ]; then
+  groupmod -g ${APP_GROUP_ID:-$CURRENT_GID} node && \
+  usermod -u ${APP_USER_ID:-$CURRENT_UID} -g ${APP_GROUP_ID:-$CURRENT_GID} node
 fi
-chown alone:alone /home/alone
-chown -R alone:alone /home/alone/app
 
 . /docker-entrypoint.sh

--- a/generated-dockerfiles/debian/8.9.4-debian/Dockerfile
+++ b/generated-dockerfiles/debian/8.9.4-debian/Dockerfile
@@ -20,13 +20,7 @@ RUN set -x \
     && gosu nobody true \
     && apt-get purge -y --auto-remove ca-certificates wget
 
-# create directory to host application files
-RUN mkdir -p /home/alone/app
-
-# this will be mounted as a volume in the build process
-WORKDIR /home/alone/app
-
-# base-entrypoint allows us to create a user/group with configureable UID/GID
+# base-entrypoint allows us to update the node uid/gid
 COPY base-entrypoint.sh /
 
 # make sure we can execute base-entrypoint.sh
@@ -35,7 +29,7 @@ RUN chmod +x /base-entrypoint.sh
 # this will be the entrypoint script for the child container
 ONBUILD COPY docker-entrypoint.sh /
 
-# this will handle creating the user/group and running the docker-entrypoint.sh
+# this will handle updating the node uid/gid and running the docker-entrypoint.sh
 # provided by the child image
 ENTRYPOINT ["/base-entrypoint.sh"]
 

--- a/generated-dockerfiles/debian/8.9.4-debian/base-entrypoint.sh
+++ b/generated-dockerfiles/debian/8.9.4-debian/base-entrypoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 
-# create alone user/group so we aren't forced to run app as root
-id -u alone 2>/dev/null
-if [ $? -ne 0 ]; then
-  groupadd -r alone --gid=$APP_GROUP_ID
-  useradd -r -g alone -d /home/alone -c "alone app user" --uid=$APP_USER_ID alone
-  echo "created alone user/group with UID/GID: $APP_USER_ID/$APP_GROUP_ID"
-else
-  echo "alone user already exists"
+CURRENT_UID=`id -u node 2>/dev/null`
+CURRENT_GID=`id -g node 2>/dev/null`
+
+# if either APP_USER_ID or APP_GROUP_ID environment variables exist,
+# the node user's uid/gid will be updated accordingly. this is useful
+# if you want to avoid permissions issues when mounting volumes
+if [ ! -z "$APP_USER_ID" -o ! -z "$APP_GROUP_ID" ]; then
+  groupmod -g ${APP_GROUP_ID:-$CURRENT_GID} node && \
+  usermod -u ${APP_USER_ID:-$CURRENT_UID} -g ${APP_GROUP_ID:-$CURRENT_GID} node
 fi
-chown alone:alone /home/alone
-chown -R alone:alone /home/alone/app
 
 . /docker-entrypoint.sh

--- a/generated-dockerfiles/debian/9.4.0-debian/Dockerfile
+++ b/generated-dockerfiles/debian/9.4.0-debian/Dockerfile
@@ -20,13 +20,7 @@ RUN set -x \
     && gosu nobody true \
     && apt-get purge -y --auto-remove ca-certificates wget
 
-# create directory to host application files
-RUN mkdir -p /home/alone/app
-
-# this will be mounted as a volume in the build process
-WORKDIR /home/alone/app
-
-# base-entrypoint allows us to create a user/group with configureable UID/GID
+# base-entrypoint allows us to update the node uid/gid
 COPY base-entrypoint.sh /
 
 # make sure we can execute base-entrypoint.sh
@@ -35,7 +29,7 @@ RUN chmod +x /base-entrypoint.sh
 # this will be the entrypoint script for the child container
 ONBUILD COPY docker-entrypoint.sh /
 
-# this will handle creating the user/group and running the docker-entrypoint.sh
+# this will handle updating the node uid/gid and running the docker-entrypoint.sh
 # provided by the child image
 ENTRYPOINT ["/base-entrypoint.sh"]
 

--- a/generated-dockerfiles/debian/9.4.0-debian/base-entrypoint.sh
+++ b/generated-dockerfiles/debian/9.4.0-debian/base-entrypoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 
-# create alone user/group so we aren't forced to run app as root
-id -u alone 2>/dev/null
-if [ $? -ne 0 ]; then
-  groupadd -r alone --gid=$APP_GROUP_ID
-  useradd -r -g alone -d /home/alone -c "alone app user" --uid=$APP_USER_ID alone
-  echo "created alone user/group with UID/GID: $APP_USER_ID/$APP_GROUP_ID"
-else
-  echo "alone user already exists"
+CURRENT_UID=`id -u node 2>/dev/null`
+CURRENT_GID=`id -g node 2>/dev/null`
+
+# if either APP_USER_ID or APP_GROUP_ID environment variables exist,
+# the node user's uid/gid will be updated accordingly. this is useful
+# if you want to avoid permissions issues when mounting volumes
+if [ ! -z "$APP_USER_ID" -o ! -z "$APP_GROUP_ID" ]; then
+  groupmod -g ${APP_GROUP_ID:-$CURRENT_GID} node && \
+  usermod -u ${APP_USER_ID:-$CURRENT_UID} -g ${APP_GROUP_ID:-$CURRENT_GID} node
 fi
-chown alone:alone /home/alone
-chown -R alone:alone /home/alone/app
 
 . /docker-entrypoint.sh


### PR DESCRIPTION
Now using provided `node` user. Updated documentation accordingly.