### PR TITLE
fix(versioning): use package.json version as version for docker images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,8 @@ machine:
 dependencies:
   override:
     - docker info
-    - cd generated-dockerfiles/debian/8.9.4-debian && docker build -t godaddy/node:8.9.4-debian .;
-    - cd generated-dockerfiles/debian/9.4.0-debian && docker build -t godaddy/node:9.4.0-debian .;
+    - version=$(node -pe "($(cat package.json)).version"); cd generated-dockerfiles/debian/8.9.4-debian && docker build -t godaddy/node:8.9.4-debian-$version .;
+    - version=$(node -pe "($(cat package.json)).version"); cd generated-dockerfiles/debian/9.4.0-debian && docker build -t godaddy/node:9.4.0-debian-$version .;
 
 test:
   override:
@@ -19,5 +19,5 @@ deployment:
     tag: /v[0-9]+(\.[0-9]+)*/
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - cd generated-dockerfiles/debian/8.9.4-debian && docker push godaddy/node:8.9.4-debian;
-      - cd generated-dockerfiles/debian/9.4.0-debian && docker push godaddy/node:9.4.0-debian;
+      - version=$(node -pe "($(cat package.json)).version"); cd generated-dockerfiles/debian/8.9.4-debian && docker push godaddy/node:8.9.4-debian-$version;
+      - version=$(node -pe "($(cat package.json)).version"); cd generated-dockerfiles/debian/9.4.0-debian && docker push godaddy/node:9.4.0-debian-$version;

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ dockerTemplates.forEach((templatePath) => {
       nodeVersion: version.nodeVersion
     });
 
-    circleDependencies.push(`- cd generated-dockerfiles/${linuxDistributionName}/${tag} && docker build -t godaddy/node:${tag} .;`);
-    circleDeployments.push(`- cd generated-dockerfiles/${linuxDistributionName}/${tag} && docker push godaddy/node:${tag};`);
+    circleDependencies.push(`- version=$(node -pe "($(cat package.json)).version"); cd generated-dockerfiles/${linuxDistributionName}/${tag} && docker build -t godaddy/node:${tag}-$version .;`);
+    circleDeployments.push(`- version=$(node -pe "($(cat package.json)).version"); cd generated-dockerfiles/${linuxDistributionName}/${tag} && docker push godaddy/node:${tag}-$version;`);
 
     mkdirp.sync(dockerFileLocation);
 


### PR DESCRIPTION
Using the `version` property from `package.json` to version the images. Immutability FTW.